### PR TITLE
Non-Standard Comparison Operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 **/bin/**
 **/libs/**
 **/obj/**
+**/Debug/**
 *.pyc
 apks/**
 docs/html/
@@ -34,3 +35,9 @@ googletest/
 local.properties
 proguard-project.txt
 project.properties
+*.vcxproj
+*.vcxproj.*
+*.sln
+*.*sdf
+*.sln
+*.suo

--- a/include/mathfu/utilities.h
+++ b/include/mathfu/utilities.h
@@ -36,6 +36,7 @@
 ///
 /// @li @ref MATHFU_COMPILE_WITHOUT_SIMD_SUPPORT
 /// @li @ref MATHFU_COMPILE_FORCE_PADDING
+/// @li @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
 ///
 /// <table>
 /// <tr>
@@ -120,6 +121,28 @@
 #define MATHFU_COMPILE_FORCE_PADDING
 /// @}
 #endif  // DOXYGEN
+
+#ifdef DOXYGEN
+/// @addtogroup mathfu_build_config
+/// @{
+/// @def MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+/// @brief Enable / disable non-standard extensions.
+///
+/// By default, when @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS is 
+/// <b>not</b> defined, only the interface defined by GLSL is present.
+///
+/// If @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS is defined, additional
+/// functionality is added outside of the GLSL standard.
+///
+/// The additional interface includes comparison operators on Vector.
+///
+/// To use this build option, this macro <b>must</b> be defined in all modules
+/// of the project.
+///
+#define MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+/// @}
+#endif  // DOXYGEN
+
 
 #ifdef MATHFU_COMPILE_WITH_SIMD
 /// @cond MATHFU_INTERNAL

--- a/include/mathfu/vector.h
+++ b/include/mathfu/vector.h
@@ -574,6 +574,112 @@ class Vector {
     return result;
   }
 
+# if defined(MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS)
+
+  /// @brief Determines if this Vector equals another Vector.
+  ///
+  /// The comparison passes if all of the components in the vectors
+  /// are equal.
+  /// 
+  /// This operator is non-standard and is not present in GLSL. To gain
+  /// access to this operator @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+  /// must be defined.
+  ///
+  /// @param v A vector to compare this vector with.
+  /// @return A bool containing the result of the comparison.
+  inline bool operator==(const Vector<T, d>& v) const {
+    bool result = true;
+    MATHFU_VECTOR_OPERATION(result &= data_[i] == v[i]);
+    return result;
+  }
+
+  /// @brief Determines if this Vector does not equal another Vector.
+  ///
+  /// The comparison passes if any one of the components in the vectors
+  /// are not equal. 
+  /// 
+  /// This operator is non-standard and is not present in GLSL. To gain
+  /// access to this operator @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+  /// must be defined.
+  ///
+  /// @param v A vector to compare this vector with.
+  /// @return A bool containing the result of the comparison.
+  inline bool operator!=(const Vector<T, d>& v) const {
+    bool result = false;
+    MATHFU_VECTOR_OPERATION(result |= data_[i] != v[i]);
+    return result;
+  }
+
+  /// @brief Determines if this Vector is less than another Vector.
+  ///
+  /// The comparison passes if any one of the components in the vectors
+  /// is less.
+  /// 
+  /// This operator is non-standard and is not present in GLSL. To gain
+  /// access to this operator @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+  /// must be defined.
+  ///
+  /// @param v A vector to compare this vector with.
+  /// @return A bool containing the result of the comparison.
+  inline bool operator<(const Vector<T, d>& v) const {
+    bool result = false;
+    MATHFU_VECTOR_OPERATION(result |= data_[i] < v[i]);
+    return result;
+  }
+
+  /// @brief Determines if this Vector is greater than another Vector.
+  ///
+  /// The comparison passes if any one of the components in the vectors
+  /// is greater. 
+  /// 
+  /// This operator is non-standard and is not present in GLSL. To gain
+  /// access to this operator @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+  /// must be defined.
+  ///
+  /// @param v A vector to compare this vector with.
+  /// @return A bool containing the result of the comparison.
+  inline bool operator>(const Vector<T, d>& v) const {
+    bool result = false;
+    MATHFU_VECTOR_OPERATION(result |= data_[i] > v[i]);
+    return result;
+  }
+
+  /// @brief Determines if this Vector is less than or equal to another Vector.
+  ///
+  /// The comparison passes if any one of the components in the vectors
+  /// is less or equal. 
+  /// 
+  /// This operator is non-standard and is not present in GLSL. To gain
+  /// access to this operator @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+  /// must be defined.
+  ///
+  /// @param v A vector to compare this vector with.
+  /// @return A bool containing the result of the comparison.
+  inline bool operator<=(const Vector<T, d>& v) const {
+    bool result = false;
+    MATHFU_VECTOR_OPERATION(result |= data_[i] <= v[i]);
+    return result;
+  }
+
+  /// @brief Determines if this Vector is greater than or equal to another Vector.
+  ///
+  /// The comparison passes if any one of the components in the vectors
+  /// is greater or equal. 
+  /// 
+  /// This operator is non-standard and is not present in GLSL. To gain
+  /// access to this operator @ref MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+  /// must be defined.
+  ///
+  /// @param v A vector to compare this vector with.
+  /// @return A bool containing the result of the comparison.
+  inline bool operator>=(const Vector<T, d>& v) const {
+    bool result = false;
+    MATHFU_VECTOR_OPERATION(result |= data_[i] >= v[i]);
+    return result;
+  }
+
+# endif // MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+
  private:
   /// Elements of the vector.
   T data_[d];

--- a/include/mathfu/vector_3.h
+++ b/include/mathfu/vector_3.h
@@ -289,6 +289,37 @@ class Vector<float, 3> {
         mathfu::RandomInRange<float>(min[2], max[2]));
   }
 
+# if defined(MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS)
+
+  // NB: The 4th bit after simd4f_getsigns will be a constant depending on the operator,
+  // this either needs to be removed or taken into account.
+
+  inline bool operator==(const Vector<float, 3>& v) const {
+    return simd4f_getsigns(simd4f_eq(MATHFU_VECTOR3_LOAD3(data_), MATHFU_VECTOR3_LOAD3(v.data_))) == 0xF; // 0xF = 1111
+  }
+
+  inline bool operator!=(const Vector<float, 3>& v) const {
+    return simd4f_getsigns(simd4f_eq(MATHFU_VECTOR3_LOAD3(data_), MATHFU_VECTOR3_LOAD3(v.data_))) != 0xF;
+  }
+
+  inline bool operator<(const Vector<float, 3>& v) const {
+    return (simd4f_getsigns(simd4f_lt(MATHFU_VECTOR3_LOAD3(data_), MATHFU_VECTOR3_LOAD3(v.data_))) & 0x7) != 0x0; // 0x7 = 1110
+  }
+
+  inline bool operator>(const Vector<float, 3>& v) const {
+    return (simd4f_getsigns(simd4f_gt(MATHFU_VECTOR3_LOAD3(data_), MATHFU_VECTOR3_LOAD3(v.data_))) & 0x7) != 0x0;
+  }
+
+  inline bool operator<=(const Vector<float, 3>& v) const {
+    return (simd4f_getsigns(simd4f_le(MATHFU_VECTOR3_LOAD3(data_), MATHFU_VECTOR3_LOAD3(v.data_))) & 0x7) != 0x0;
+  }
+
+  inline bool operator>=(const Vector<float, 3>& v) const {
+    return (simd4f_getsigns(simd4f_ge(MATHFU_VECTOR3_LOAD3(data_), MATHFU_VECTOR3_LOAD3(v.data_))) & 0x7) != 0x0;
+  }
+
+# endif // MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+
   template<class T, int rows, int cols> friend class Matrix;
   template<class T, int d> friend class Vector;
 

--- a/include/mathfu/vector_4.h
+++ b/include/mathfu/vector_4.h
@@ -221,6 +221,34 @@ class Vector<float, 4> {
         mathfu::RandomInRange<float>(min[3], max[3]));
   }
 
+# if defined(MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS)
+
+  inline bool operator==(const Vector<float, 4>& v) const {
+    return simd4f_getsigns(simd4f_eq(data_.simd, v.data_.simd)) == 0xF;
+  }
+
+  inline bool operator!=(const Vector<float, 4>& v) const {
+    return simd4f_getsigns(simd4f_eq(data_.simd, v.data_.simd)) != 0xF;
+  }
+
+  inline bool operator<(const Vector<float, 4>& v) const {
+    return simd4f_getsigns(simd4f_lt(data_.simd, v.data_.simd)) != 0x0;
+  }
+
+  inline bool operator>(const Vector<float, 4>& v) const {
+    return simd4f_getsigns(simd4f_gt(data_.simd, v.data_.simd)) != 0x0;
+  }
+
+  inline bool operator<=(const Vector<float, 4>& v) const {
+    return simd4f_getsigns(simd4f_le(data_.simd, v.data_.simd)) != 0x0;
+  }
+
+  inline bool operator>=(const Vector<float, 4>& v) const {
+    return simd4f_getsigns(simd4f_ge(data_.simd, v.data_.simd)) != 0x0;
+  }
+
+# endif // MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+
   template<class T, int rows, int cols> friend class Matrix;
 
  private:

--- a/unit_tests/vector_test/vector_test.cpp
+++ b/unit_tests/vector_test/vector_test.cpp
@@ -13,6 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
+// Allow non-standard extensions so that they can be
+// tested.
+#define MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS
+
 #include "mathfu/vector.h"
 #include "mathfu/vector_2.h"
 #include "mathfu/vector_3.h"
@@ -258,6 +263,87 @@ void Mult_Test(const T& precision) {
 }
 TEST_ALL_F(Mult)
 
+// This will test the comparison of vectors by vectors and scalars. The
+// template paramter d corresponds to the size of the vector.
+template<class T, int d>
+void Comp_Test(const T&) {
+  T x1[d], x2[d];
+  for (int i = 0; i < d; ++i) x1[i] = rand() / static_cast<T>(RAND_MAX);
+  for (int i = 0; i < d; ++i) x2[i] = rand() / static_cast<T>(RAND_MAX);
+  mathfu::Vector<T, d> vector1(x1), vector2(x2);
+  // This will test the equality of two vectors and verify that each
+  // element is equal.
+  bool truth = true;
+  for (int i = 0; i < d; ++i) {
+    truth &= x1[i] == x2[i];
+  }
+  EXPECT_EQ(truth, vector1 == vector2);
+  // This will test the inequality of two vectors and verify that any
+  // element is unequal.
+  truth = false;
+  for (int i = 0; i < d; ++i) {
+    truth |= x1[i] != x2[i];
+  }
+  EXPECT_EQ(truth, vector1 != vector2);
+  // This will test the value of two vectors and verify that any
+  // element is less-than.
+  truth = false;
+  for (int i = 0; i < d; ++i) {
+    truth |= x1[i] < x2[i];
+  }
+  EXPECT_EQ(truth, vector1 < vector2);
+  // This will test the value of two vectors and verify that any
+  // element is greater-than.
+  truth = false;
+  for (int i = 0; i < d; ++i) {
+    truth |= x1[i] > x2[i];
+  }
+  EXPECT_EQ(truth, vector1 > vector2);
+  // This will test the value of two vectors and verify that any
+  // element is less-than or equal.
+  truth = false;
+  for (int i = 0; i < d; ++i) {
+    truth |= x1[i] <= x2[i];
+  }
+  EXPECT_EQ(truth, vector1 <= vector2);
+  // This will test the value of two vectors and verify that any
+  // element is greater-than or equal.
+  truth = false;
+  for (int i = 0; i < d; ++i) {
+    truth |= x1[i] >= x2[i];
+  }
+  EXPECT_EQ(truth, vector1 >= vector2);
+  // Tests with all values satisfying the condition.
+  for (int i = 0; i < d; ++i) x1[i] = static_cast<T>(1);
+  for (int i = 0; i < d; ++i) x2[i] = static_cast<T>(0);
+  vector1 = mathfu::Vector<T, d>(x1), vector2 = mathfu::Vector<T, d>(x2);
+  EXPECT_FALSE(vector1 == vector2);
+  EXPECT_TRUE (vector1 != vector2);
+  EXPECT_FALSE(vector1 < vector2);
+  EXPECT_TRUE (vector1 > vector2);
+  EXPECT_FALSE(vector1 <= vector2);
+  EXPECT_TRUE (vector1 >= vector2);
+  EXPECT_TRUE (vector2 < vector1);
+  EXPECT_FALSE(vector2 > vector1);
+  EXPECT_TRUE (vector2 <= vector1);
+  EXPECT_FALSE(vector2 >= vector1);
+  // Tests with one value satisfying the condition.
+  for (int i = 1; i < d; ++i) x1[i] = static_cast<T>(1);
+  for (int i = 1; i < d; ++i) x2[i] = static_cast<T>(0);
+  vector1 = mathfu::Vector<T, d>(x1), vector2 = mathfu::Vector<T, d>(x2);
+  EXPECT_FALSE(vector1 == vector2);
+  EXPECT_TRUE(vector1 != vector2);
+  EXPECT_FALSE(vector1 < vector2);
+  EXPECT_TRUE(vector1 > vector2);
+  EXPECT_FALSE(vector1 <= vector2);
+  EXPECT_TRUE(vector1 >= vector2);
+  EXPECT_TRUE(vector2 < vector1);
+  EXPECT_FALSE(vector2 > vector1);
+  EXPECT_TRUE(vector2 <= vector1);
+  EXPECT_FALSE(vector2 >= vector1);
+}
+TEST_ALL_F(Comp)
+
 // This will test normalizing a vector. The template parameter d corresponds to
 // the size of the vector.
 template<class T, int d>
@@ -438,7 +524,7 @@ void RandomInRange_Test(const T& precision) {
   for (int count = 0; count < 100; count++) {
     T result = mathfu::RandomInRange(
       static_cast<T>(-100), static_cast<T>(0));
-    EXPECT_GT(result, -100);
+    EXPECT_GE(result, -100);
     EXPECT_LE(result, 0);
   }
   EXPECT_EQ(0, mathfu::RandomInRange(0, 0));

--- a/unit_tests/vector_test/vector_test.cpp
+++ b/unit_tests/vector_test/vector_test.cpp
@@ -327,20 +327,18 @@ void Comp_Test(const T&) {
   EXPECT_FALSE(vector2 > vector1);
   EXPECT_TRUE (vector2 <= vector1);
   EXPECT_FALSE(vector2 >= vector1);
-  // Tests with one value satisfying the condition.
-  for (int i = 1; i < d; ++i) x1[i] = static_cast<T>(1);
-  for (int i = 1; i < d; ++i) x2[i] = static_cast<T>(0);
-  vector1 = mathfu::Vector<T, d>(x1), vector2 = mathfu::Vector<T, d>(x2);
+  // Tests with different values.
+  vector1[0] = static_cast<T>(0);
   EXPECT_FALSE(vector1 == vector2);
-  EXPECT_TRUE(vector1 != vector2);
+  EXPECT_TRUE (vector1 != vector2);
   EXPECT_FALSE(vector1 < vector2);
-  EXPECT_TRUE(vector1 > vector2);
-  EXPECT_FALSE(vector1 <= vector2);
-  EXPECT_TRUE(vector1 >= vector2);
-  EXPECT_TRUE(vector2 < vector1);
+  EXPECT_TRUE (vector1 > vector2);
+  EXPECT_TRUE (vector1 <= vector2);
+  EXPECT_TRUE (vector1 >= vector2);
+  EXPECT_TRUE (vector2 < vector1);
   EXPECT_FALSE(vector2 > vector1);
-  EXPECT_TRUE(vector2 <= vector1);
-  EXPECT_FALSE(vector2 >= vector1);
+  EXPECT_TRUE (vector2 <= vector1);
+  EXPECT_TRUE (vector2 >= vector1);
 }
 TEST_ALL_F(Comp)
 


### PR DESCRIPTION
In games comparison operators between vectors are frequently used _outside_ of the shaders (e.g. when implementing an AABB). It makes sense that a C++ developer would want access to these in her math library.

I have **optional** added support to mathfu for these operators. Unfortunately I do not know how to develop against Neon, nor I do I have access to a Neon device, so the SSE functions for that architecture is unimplemented (i.e. this PR is incomplete). If you guys think this belongs in mathfu you will have to fill in the blanks.

Additionally, I am unsure of how to PR multiple branches. The vectorial changes are here: https://github.com/jcdickinson/mathfu/commit/d7a6fb924517943518432054415333c7930a9ecc - I can open a PR for that if it would help.

*COMPLETE:*

- Adding Visual Studio stuff to .gitignore.
- Defining comparison operators on Vector.
- Comparison operators must be enabled by defining `MATHFU_COMPILE_WITH_NON_STANDARD_EXTENSIONS`

*INCOMPLETE:*

- Neon SSE implementation. I don't have the required knowledge to code this or test this.
 - GNU and Scalar implementations are untested.
- I have corrected what looks like a false negative in `RandomInRange_Test`.
- New random values (due to more preceding tests) have either exposed a bug in the test, or exposed a bug in the implementation. Please validate.