### PR TITLE
Add UnProject function to Matrix class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ googletest/
 local.properties
 proguard-project.txt
 project.properties
+.DS_Store

--- a/include/mathfu/matrix.h
+++ b/include/mathfu/matrix.h
@@ -122,6 +122,13 @@ static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
                                            const Vector<T, 3>& eye,
                                            const Vector<T, 3>& up,
                                            T handedness);
+template <class T>
+static inline bool UnProjectHelper(const Vector<T, 3> window_coord,
+                                   const Matrix<T, 4, 4> model_view,
+                                   const Matrix<T, 4, 4> projection,
+                                   const float window_width,
+                                   const float window_height,
+                                   Vector<T, 3>& result);
 /// @endcond
 
 /// @addtogroup mathfu_matrix
@@ -751,6 +758,28 @@ class Matrix {
     return LookAtHelper(at, eye, up, handedness);
   }
 
+  /// @brief Get the 3D position in object space from a window coordinate.
+  ///
+  /// @param window_coord The window coordinate. The z value is for depth.
+  /// A window coordinate on the near plane will have 0 as the z value.
+  /// And a window coordinate on the far plane will have 1 as the z value.
+  /// z value should be with in [0, 1] here.
+  /// @param model_view The Model View matrix.
+  /// @param projection The projection matrix.
+  /// @param window_width Width of the window.
+  /// @param window_height Height of the window.
+  /// @return the mapped 3D position in object space.
+  static inline Vector<T, 3> UnProject(const Vector<T, 3> window_coord,
+                                       const Matrix<T, 4, 4> model_view,
+                                       const Matrix<T, 4, 4> projection,
+                                       const float window_width,
+                                       const float window_height) {
+    Vector<T, 3> result;
+    UnProjectHelper(window_coord, model_view, projection, window_width,
+                    window_height, result);
+    return result;
+  }
+
   /// @brief Multiply a Vector by a Matrix.
   ///
   /// @param v Vector to multiply.
@@ -1357,6 +1386,40 @@ static inline Matrix<T, 4, 4> LookAtHelper(const Vector<T, 3>& at,
   const Vector<T, 4> column2(axes[0][2], axes[1][2], axes[2][2], 0);
   const Vector<T, 4> column3(axes[3], 1);
   return Matrix<T, 4, 4>(column0, column1, column2, column3);
+}
+/// @endcond
+
+/// @cond MATHFU_INTERNAL
+/// Get the 3D position in object space from a window coordinate.
+template <class T>
+static inline bool UnProjectHelper(const Vector<T, 3> window_coord,
+                                   const Matrix<T, 4, 4> model_view,
+                                   const Matrix<T, 4, 4> projection,
+                                   const float window_width,
+                                   const float window_height,
+                                   Vector<T, 3>& result) {
+  if (window_coord.z() < static_cast<T>(0) ||
+      window_coord.z() > static_cast<T>(1)) {
+    // window_coord.z should be with in [0, 1]
+    // 0: near plane
+    // 1: far plane
+    return false;
+  }
+  Matrix<T, 4, 4> matrix = (projection * model_view).Inverse();
+  Vector<T, 4> standardized = Vector<T, 4>(
+      static_cast<T>(2) * (window_coord.x() - window_width) / window_width +
+          static_cast<T>(1),
+      static_cast<T>(2) * (window_coord.y() - window_height) / window_height +
+          static_cast<T>(1),
+      static_cast<T>(2) * window_coord.z() - static_cast<T>(1),
+      static_cast<T>(1));
+
+  Vector<T, 4> multiply = matrix * standardized;
+  if (multiply.w() == static_cast<T>(0)) {
+    return false;
+  }
+  result = multiply.xyz() / multiply.w();
+  return true;
 }
 /// @endcond
 

--- a/include/mathfu/matrix_4x4.h
+++ b/include/mathfu/matrix_4x4.h
@@ -359,6 +359,28 @@ class Matrix<float, 4> {
     return LookAtHelper(at, eye, up, handedness);
   }
 
+  /// @brief Get the 3D position in object space from a window coordinate.
+  ///
+  /// @param window_coord The window coordinate. The z value is for depth.
+  /// A window coordinate on the near plane will have 0 as the z value.
+  /// And a window coordinate on the far plane will have 1 as the z value.
+  /// z value should be with in [0, 1] here.
+  /// @param model_view The Model View matrix.
+  /// @param projection The projection matrix.
+  /// @param window_width Width of the window.
+  /// @param window_height Height of the window.
+  /// @return the mapped 3D position in object space.
+  static inline Vector<float, 3> UnProject(const Vector<float, 3> window_coord,
+                                           const Matrix<float, 4, 4> model_view,
+                                           const Matrix<float, 4, 4> projection,
+                                           const float window_width,
+                                           const float window_height) {
+    Vector<float, 3> result;
+    UnProjectHelper(window_coord, model_view, projection, window_width,
+                    window_height, result);
+    return result;
+  }
+
   // Dimensions of the matrix.
   /// Number of rows in the matrix.
   static const int kRows = 4;

--- a/unit_tests/matrix_test/matrix_test.cpp
+++ b/unit_tests/matrix_test/matrix_test.cpp
@@ -762,6 +762,28 @@ void LookAt_Test(const T& precision) {
 }
 TEST_SCALAR_F(LookAt, FLOAT_PRECISION, kLookAtDoublePrecision);
 
+// Test UnProject calculation.
+TEST_F(MatrixTests, UnProjectTest) {
+  // clang-format off
+  mathfu::Matrix<float, 4, 4> modelView = 
+      mathfu::Matrix<float, 4, 4>(-1, 0,   0, 0,
+                                   0, 1,   0, 0,
+                                   0, 0,  -1, 0,
+                                   0, 0, -10, 1);
+  mathfu::Matrix<float, 4, 4> projection = 
+      mathfu::Matrix<float, 4, 4> (1.81066,          0,            0,  0,
+                                         0, 2.41421342,            0,  0,
+                                         0,          0,  -1.00001991, -1,
+                                         0,          0, -0.200001985,  0);
+  // clang-format on
+  mathfu::Vector<float, 3> result = mathfu::Matrix<float, 4, 4>::UnProject(
+      mathfu::Vector<float, 3>(754, 1049, 1), modelView, projection, 1600,
+      1200);
+  EXPECT_NEAR(result.x(), 318.650543, FLOAT_PRECISION);
+  EXPECT_NEAR(result.y(), 3110.3056640625, FLOAT_PRECISION);
+  EXPECT_NEAR(result.z(), 10024.19140625, FLOAT_PRECISION);
+}
+
 // Test matrix transposition.
 template<class T, int d>
 void Transpose_Test(const T& precision) {


### PR DESCRIPTION
Below is the added function:
```patch
+  static inline Vector<T, 3> UnProject(const Vector<T, 3>  windowCoord, 
+                                       const Matrix<T, 4, 4> modelView,
+                                       const Matrix<T, 4, 4> projection,
+                                       const float windowWidth,
+                                       const float windowHeight)
```

It's has the same functionality as the [gluUnProject](https://www.opengl.org/sdk/docs/man2/xhtml/gluUnProject.xml) from the OpenGL Utility Library.