### PR TITLE
Fix MSVC throwing C4201, this feature is standard >=C++11

### DIFF
--- a/include/mathfu/internal/disable_warnings_begin.h
+++ b/include/mathfu/internal/disable_warnings_begin.h
@@ -33,3 +33,8 @@
 #pragma clang diagnostic ignored "-Wpedantic"
 #pragma clang diagnostic ignored "-Wignored-qualifiers"
 #endif  // defined(__clang__)
+
+#if defined(_MSC_VER)
+#pragma warning( push )
+#pragma warning( disable : 4201 )
+#endif // defined(_MSC_VER)

--- a/include/mathfu/internal/disable_warnings_end.h
+++ b/include/mathfu/internal/disable_warnings_end.h
@@ -21,3 +21,7 @@
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif  // defined(__GNUC__)
+
+#if defined(_MSC_VER)
+#pragma warning( pop )
+#endif // defined(_MSC_VER)


### PR DESCRIPTION
Even though nameless struct/unions are standardized since C++11, MSVC still complains that this is a non-standard feature.